### PR TITLE
fix: add stacking behavior to serialized field

### DIFF
--- a/Runtime/EffectSystem/ScriptableObjects/GameplayEffectSO.cs
+++ b/Runtime/EffectSystem/ScriptableObjects/GameplayEffectSO.cs
@@ -30,7 +30,7 @@ namespace H2V.GameplayAbilitySystem.EffectSystem.ScriptableObjects
         [field: SerializeField, Tooltip("What attribute to affect and how it affected")]
         public EffectDetails EffectDetails { get; private set; } = new();
 
-        [field: SerializeField]
+        [field: SerializeReference, Tooltip("Stacking effect when this effect is applied on the target")]
         public StackingDetails StackingDetails { get; private set; }
 
         [field: SerializeReference, SubclassSelector, Tooltip("Addition effect when this effect is applied on the target")]


### PR DESCRIPTION
- **Updated** `[field: SerializeField]` to `[field: SerializeReference, Tooltip("Stacking effect when this effect is applied on the target")]`.
- **Enhancement**: Added `SerializeReference` for polymorphic serialization support, allowing use of derived types in the field.
- **Tooltip Added**: Added a tooltip to clarify the stacking effect behavior when applied to the target.